### PR TITLE
Change the model signing to use the model-signing library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ datasets>=2.18.0
 gguf>=0.6.0
 GitPython>=3.1.42
 sigstore>=3.0.0
+model-signing>=0.2.0
 # Linux: 4-bit quantization with BitsAndBytes is not ready to use, yet.
 # see https://github.com/instructlab/instructlab/issues/579
 # bitsandbytes; sys_platform=='linux' and platform_machine=='x86_64'

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -67,6 +67,8 @@ aliases = {
     "download": {"group": model_group.model, "cmd": model_group.download},
     "diff": {"group": taxonomy_group.taxonomy, "cmd": taxonomy_group.diff},
     "generate": {"group": data_group.data, "cmd": data_group.generate},
+    "sign": {"group": model_group.model, "cmd": model_group.sign},
+    "verify": {"group": model_group.model, "cmd": model_group.verify},
 }
 
 

--- a/src/instructlab/model/sign.py
+++ b/src/instructlab/model/sign.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from os.path import dirname, join
 from pathlib import Path
 
 # Third Party
@@ -15,30 +16,44 @@ from instructlab import signing, utils
 @click.option(
     "--model-path",
     type=click.Path(),
-    default=config.DEFAULT_MODEL_PATH,
+    default=dirname(config.DEFAULT_MODEL_PATH),
     show_default=True,
-    help="Path to the model to be signed.",
+    help="Path to the directory of the model to be signed.",
 )
 @click.option(
-    "--bundle-path",
+    "--sig_out",
     type=click.Path(),
     default=None,
-    show_default=True,
+    show_default=False,
     help="Path to save the Sigstore bundle file after signing.",
 )
 @click.option(
-    "--staging",
+    "--use-ambient-credentials",
     is_flag=True,
-    help="Use Sigstore's staging environment.",
+    show_default=True,
+    default=False,
+    help="use ambient credentials (also known as Workload Identity)",
 )
-@click.pass_context
+@click.option(
+    "--identity-token",
+    type=click.STRING,
+    default=None,
+    show_default=False,
+    help="Optional identity token",
+)
 @utils.display_params
-def sign(ctx, model_path, bundle_path, staging):
+def sign(model_path, sig_out, use_ambient_credentials, identity_token):
     """Signs a model with Sigstore"""
+    if sig_out is None:
+        sig_out = join(model_path, "model.sig")
 
-    if bundle_path is None:
-        bundle_path = f"{model_path}.sigstore.json"
-
-    signing.sign_model(
-        model_path=Path(model_path), bundle_path=Path(bundle_path), staging=staging
-    )
+    try:
+        signing.sign_model(
+            model_path=Path(model_path),
+            sig_out=Path(sig_out),
+            use_ambient_credentials=use_ambient_credentials,
+            identity_token=identity_token,
+        )
+    except Exception as e:
+        click.secho(f"Could not sign model in {model_path}: {e}", fg="red")
+        raise click.exceptions.Exit(1)

--- a/src/instructlab/model/verify.py
+++ b/src/instructlab/model/verify.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+import sys
+from os.path import dirname, join
 from pathlib import Path
 
 # Third Party
-from sigstore.errors import VerificationError
 import click
 
 # First Party
@@ -16,16 +17,16 @@ from instructlab import signing, utils
 @click.option(
     "--model-path",
     type=click.Path(),
-    default=config.DEFAULT_MODEL_PATH,
+    default=dirname(config.DEFAULT_MODEL_PATH),
     show_default=True,
-    help="Path to the model to be signed.",
+    help="Path to the directory where the signed model is located.",
 )
 @click.option(
-    "--bundle-path",
+    "--signature",
     type=click.Path(),
     default=None,
-    show_default=True,
-    help="Path to save the Sigstore bundle file after signing.",
+    show_default=False,
+    help="Path to the signature. By default model.sig in the model path will be used.",
 )
 @click.option(
     "--identity",
@@ -40,26 +41,31 @@ from instructlab import signing, utils
     show_default=True,
 )
 @click.option(
-    "--staging",
+    "--yes",
     is_flag=True,
-    help="Use Sigstore's staging environment.",
+    show_default=True,
+    default=False,
+    help="Answer all interactive questions with 'yes'",
 )
-@click.pass_context
 @utils.display_params
-def verify(ctx, model_path, bundle_path, identity, issuer, staging):
+def verify(model_path, signature, identity, issuer, yes):
     """Signs a model with Sigstore"""
 
-    if bundle_path is None:
-        bundle_path = f"{model_path}.sigstore.json"
+    if signature is None:
+        signature = join(model_path, "model.sig")
 
     try:
+        if not identity or not issuer:
+            identity, issuer = signing.get_oidc_params_from_sigfile(Path(signature))
+            if not signing.confirm(f"Use identity '{identity}' and issuer '{issuer}' from {signature}? [y/N] ", yes):
+                sys.exit(1)
         signing.verify_model(
             model_path=Path(model_path),
-            bundle_path=Path(bundle_path),
+            signature_file=Path(signature),
             identity=identity,
             issuer=issuer,
-            staging=staging,
         )
-        print(f"✅ {bundle_path} passed verification")
-    except VerificationError as e:
-        print(f"❌ {bundle_path} failed verification: {str(e)}")
+        print(f"✅ {model_path} passed verification")
+    except Exception as e:
+        click.secho(f"❌ {model_path} failed verification: {e}", fg="red")
+        raise click.exceptions.Exit(1)

--- a/src/instructlab/signing.py
+++ b/src/instructlab/signing.py
@@ -1,80 +1,133 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+import glob
 from pathlib import Path
-import hashlib
+from typing import List, Optional
+from os.path import join
 
 # Third Party
-from sigstore.hashes import Hashed
-from sigstore.models import Bundle
+from cryptography.x509 import (
+    ExtensionNotFound,
+    RFC822Name,
+    SubjectAlternativeName,
+)
 from sigstore.oidc import Issuer
-from sigstore.sign import SigningContext
-from sigstore.verify import Verifier
-from sigstore.verify.policy import Identity
-from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
+from sigstore import models
+from sigstore.verify.policy import OIDCIssuer
+from model_signing import model
+from model_signing.hashing import file
+from model_signing.hashing import memory
+from model_signing.serialization import serialize_by_file
+from model_signing.signing import in_toto
+from model_signing.signing import sign_sigstore as sigstore
 
 
-def sign_model(model_path: Path, bundle_path: Path, staging: bool = False) -> None:
+def _create_git_related_files(model_path: Path) -> List[str]:
+    return glob.glob(join(model_path, '.git*'))
+
+
+# Create a list of ignored paths; include git related files there
+def _create_ignored_paths(paths: List[str], model_path: Path) -> List[str]:
+    return paths + _create_git_related_files(model_path)
+
+
+def confirm(msg: str, yes: bool) -> bool:
+    """ Have the user respond to a message with either y or n"""
+    while True:
+        print(msg, end='')
+        if yes:
+            print("y\n")
+            return True
+        answer = input("")
+        if answer in ['y', 'Y']:
+            return True
+        if answer in ['n', 'N']:
+            return False
+
+
+def get_oidc_params_from_sigfile(sigfile: Path) -> (Optional[str], Optional[str]):
+    """Get the OIDC parameters of email and issuer from the in-toto signature file"""
+    data = sigfile.read_text()
+    bundle = models.Bundle.from_json(data)
+
+    signing_cert = bundle.signing_certificate
+    # SAN holds the identity's email
+    san_ext = signing_cert.extensions.get_extension_for_class(SubjectAlternativeName).value
+    all_sans = san_ext.get_values_for_type(RFC822Name)
+    if len(all_sans) != 1:
+        raise ValueError(f"Expected to find 1 email address in certificate's SAN: {all_sans}")
+
+    try:
+        ext = signing_cert.extensions.get_extension_for_oid(OIDCIssuer.oid).value
+    except ExtensionNotFound as ex:
+        raise ValueError(f"Could not get issuer from certificate extension {OIDCIssuer.oid}") from ex
+    return all_sans[0], ext.value.decode()
+
+
+def sign_model(
+    model_path: Path,
+    sig_out: Path,
+    use_ambient_credentials: bool,
+    identity_token: Optional[str] = None
+) -> None:
     """Signs a model with Sigstore"""
 
-    # Sigstore setup
-    if staging:
-        issuer = Issuer.staging()
-        signing_ctx = SigningContext.staging()
-    else:
+    def hasher_factory(file_path: Path) -> file.FileHasher:
+        return file.SimpleFileHasher(
+            file=file_path, content_hasher=memory.SHA256()
+        )
+
+    serializer = serialize_by_file.ManifestSerializer(
+        file_hasher_factory=hasher_factory
+    )
+
+    if not identity_token:
         issuer = Issuer.production()
-        signing_ctx = SigningContext.production()
-    identity = issuer.identity_token()
+        identity_token = issuer.identity_token()
 
-    # Hash the model file
-    model_hash = incremental_hash(model_path=model_path)
+    payload_signer = sigstore.SigstoreDSSESigner(
+        use_ambient_credentials=use_ambient_credentials,
+        use_staging=False,
+        identity_token=identity_token,
+    )
 
-    # Sign the model's hash and write Sigstore bundle to disk
-    with signing_ctx.signer(identity, cache=True) as signer:
-        result = signer.sign_artifact(model_hash)
-    with bundle_path.open("w", encoding="utf8") as bundle_file:
-        bundle_file.write(result.to_json())
+    sig = model.sign(
+        model_path=model_path,
+        signer=payload_signer,
+        payload_generator=in_toto.DigestsIntotoPayload.from_manifest,
+        serializer=serializer,
+        ignore_paths=_create_ignored_paths([sig_out], model_path)
+    )
+
+    sig.write(sig_out)
+    print(f"Wrote signature to {sig_out}.")
 
 
 def verify_model(
     model_path: Path,
-    bundle_path: Path,
+    signature_file: Path,
     identity: str,
     issuer: str,
-    staging: bool = False,
 ) -> None:
     """Verifies a model and its bundle with Sigstore"""
 
-    # Sigstore setup
-    if staging:
-        verifier = Verifier.staging()
-    else:
-        verifier = Verifier.production()
-
-    # Hash the model file
-    model_hash = incremental_hash(model_path=model_path)
-
-    # Read the Sigstore bundle to verify with from disk
-    bundle = Bundle.from_json(bundle_path.read_bytes())
-
-    # Verify the model hash against the bundle
-    verifier.verify_artifact(
-        model_hash,
-        bundle,
-        Identity(
-            identity=identity,
-            issuer=issuer,
-        ),
+    verifier = sigstore.SigstoreDSSEVerifier(
+        identity=identity, oidc_issuer=issuer
     )
+    sig = sigstore.SigstoreSignature.read(signature_file)
+    def hasher_factory(file_path: Path) -> file.FileHasher:
+        return file.SimpleFileHasher(
+            file=file_path, content_hasher=memory.SHA256()
+        )
 
-
-def incremental_hash(model_path: Path) -> Hashed:
-    """Incrementally hash a file and create a sigstore.hashes.Hashed object"""
-    h = hashlib.sha256()
-    with model_path.open("rb") as f:
-        while True:
-            buf = f.read(128 * 1024)
-            if not buf:
-                break
-            h.update(buf)
-    return Hashed(algorithm=HashAlgorithm.SHA2_256, digest=h.digest())
+    serializer = serialize_by_file.ManifestSerializer(
+        file_hasher_factory=hasher_factory
+    )
+    model.verify(
+        sig=sig,
+        verifier=verifier,
+        model_path=model_path,
+        serializer=serializer,
+        ignore_paths=_create_ignored_paths([signature_file], model_path)
+    )


### PR DESCRIPTION
Use the model-signing library rather than sigstore to sign and verify all files associated with a model.

FYI, in case you are interested...